### PR TITLE
add libm to link_libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ include_directories(source)
 
 link_libraries (
    ${SDL_LIBRARY}
+   m
 )
 
 add_definitions("-Wall -std=c99 --pedantic")


### PR DESCRIPTION
Fix of the error "undefined reference to symbol 'cos@@GLIBC_2.2.5'"
